### PR TITLE
Rename to uhttp

### DIFF
--- a/.changeset/thin-otters-smoke.md
+++ b/.changeset/thin-otters-smoke.md
@@ -1,0 +1,5 @@
+---
+'uhttp-exit-app': patch
+---
+
+Rename to uHTTP

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -76,7 +76,7 @@ jobs:
               id: meta
               uses: docker/metadata-action@v5
               with:
-                  images: europe-west3-docker.pkg.dev/${{ secrets.GOOGLE_HOPRASSOCIATION_PROJECT }}/docker-images/phttp-exit-app
+                  images: europe-west3-docker.pkg.dev/${{ secrets.GOOGLE_HOPRASSOCIATION_PROJECT }}/docker-images/uhttp-exit-app
                   tags: |
                       type=semver,pattern={{version}}
                       type=ref,event=pr

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# pHTTP-exit-app
+# uhttp-exit-app
 
 ## 3.0.1
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# pHTTP Exit App
+# u(nlinked)HTTP exit application
 
 ## Description
 
-pHTTP Exit Application attaches to an exit node and performs arbitrary incoming HTTP requests for clients.
+uHTTP exit application attaches to an exit node and performs arbitrary incoming HTTP requests for clients.
 
 ## Run with Docker
 

--- a/flake.nix
+++ b/flake.nix
@@ -1,5 +1,5 @@
 {
-  description = "p(rivate)HTTP exit app dev shell";
+  description = "u(nlinked)HTTP exit app dev shell";
 
   inputs.flake-utils.url = "github:numtide/flake-utils";
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-    "name": "pHTTP-exit-app",
+    "name": "uhttp-exit-app",
     "version": "3.0.1",
-    "description": "privateHTTP exit application",
+    "description": "u(nlinked)HTTP exit application",
     "author": "HOPR Association",
     "main": "src/index.ts",
     "license": "GPL-3.0",
@@ -32,7 +32,7 @@
         "typescript": "^5.4.5"
     },
     "dependencies": {
-        "@hoprnet/phttp-lib": "^3.0.1",
+        "@hoprnet/uhttp-lib": "^3.0.2",
         "debug": "^4.3.4",
         "isomorphic-ws": "^5.0.0",
         "sqlite3": "^5.1.7",

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,7 @@ import {
     Segment,
     SegmentCache,
     Utils,
-} from '@hoprnet/phttp-lib';
+} from '@hoprnet/uhttp-lib';
 
 import log from './logger';
 import * as RequestStore from './request-store';
@@ -549,35 +549,35 @@ function determineRPCmethod(body?: string) {
 
 // if this file is the entrypoint of the nodejs process
 if (require.main === module) {
-    if (!process.env.PHTTP_EA_PRIVATE_KEY) {
-        throw new Error("Missing 'PHTTP_EA_PRIVATE_KEY' env var.");
+    if (!process.env.UHTTP_EA_PRIVATE_KEY) {
+        throw new Error("Missing 'UHTTP_EA_PRIVATE_KEY' env var.");
     }
-    if (!process.env.PHTTP_EA_PUBLIC_KEY) {
-        throw new Error("Missing 'PHTTP_EA_PUBLIC_KEY' env var.");
+    if (!process.env.UHTTP_EA_PUBLIC_KEY) {
+        throw new Error("Missing 'UHTTP_EA_PUBLIC_KEY' env var.");
     }
-    if (!process.env.PHTTP_EA_HOPRD_ENDPOINT) {
-        throw new Error("Missing 'PHTTP_EA_HOPRD_ENDPOINT' env var.");
+    if (!process.env.UHTTP_EA_HOPRD_ENDPOINT) {
+        throw new Error("Missing 'UHTTP_EA_HOPRD_ENDPOINT' env var.");
     }
-    if (!process.env.PHTTP_EA_HOPRD_ACCESS_TOKEN) {
-        throw new Error("Missing 'PHTTP_EA_HOPRD_ACCESS_TOKEN' env var.");
+    if (!process.env.UHTTP_EA_HOPRD_ACCESS_TOKEN) {
+        throw new Error("Missing 'UHTTP_EA_HOPRD_ACCESS_TOKEN' env var.");
     }
-    if (!process.env.PHTTP_EA_DISCOVERY_PLATFORM_ENDPOINT) {
-        throw new Error("Missing 'PHTTP_EA_DISCOVERY_PLATFORM_ENDPOINT' env var.");
+    if (!process.env.UHTTP_EA_DISCOVERY_PLATFORM_ENDPOINT) {
+        throw new Error("Missing 'UHTTP_EA_DISCOVERY_PLATFORM_ENDPOINT' env var.");
     }
-    if (!process.env.PHTTP_EA_DISCOVERY_PLATFORM_ACCESS_TOKEN) {
-        throw new Error("Missing 'PHTTP_EA_DISCOVERY_PLATFORM_ACCESS_TOKEN' env var.");
+    if (!process.env.UHTTP_EA_DISCOVERY_PLATFORM_ACCESS_TOKEN) {
+        throw new Error("Missing 'UHTTP_EA_DISCOVERY_PLATFORM_ACCESS_TOKEN' env var.");
     }
-    if (!process.env.PHTTP_EA_DATABASE_FILE) {
-        throw new Error("Missing 'PHTTP_EA_DATABASE_FILE' env var.");
+    if (!process.env.UHTTP_EA_DATABASE_FILE) {
+        throw new Error("Missing 'UHTTP_EA_DATABASE_FILE' env var.");
     }
 
     start({
-        privateKey: process.env.PHTTP_EA_PRIVATE_KEY,
-        publicKey: process.env.PHTTP_EA_PUBLIC_KEY,
-        apiEndpoint: new URL(process.env.PHTTP_EA_HOPRD_ENDPOINT),
-        accessToken: process.env.PHTTP_EA_HOPRD_ACCESS_TOKEN,
-        discoveryPlatformEndpoint: process.env.PHTTP_EA_DISCOVERY_PLATFORM_ENDPOINT,
-        nodeAccessToken: process.env.PHTTP_EA_DISCOVERY_PLATFORM_ACCESS_TOKEN,
-        dbFile: process.env.PHTTP_EA_DATABASE_FILE,
+        privateKey: process.env.UHTTP_EA_PRIVATE_KEY,
+        publicKey: process.env.UHTTP_EA_PUBLIC_KEY,
+        apiEndpoint: new URL(process.env.UHTTP_EA_HOPRD_ENDPOINT),
+        accessToken: process.env.UHTTP_EA_HOPRD_ACCESS_TOKEN,
+        discoveryPlatformEndpoint: process.env.UHTTP_EA_DISCOVERY_PLATFORM_ENDPOINT,
+        nodeAccessToken: process.env.UHTTP_EA_DISCOVERY_PLATFORM_ACCESS_TOKEN,
+        dbFile: process.env.UHTTP_EA_DATABASE_FILE,
     });
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -564,21 +564,21 @@
   resolved "https://registry.yarnpkg.com/@gar/promisify/-/promisify-1.1.3.tgz#555193ab2e3bb3b6adc3d551c9c030d9e860daf6"
   integrity sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==
 
-"@hoprnet/phttp-crypto@^1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@hoprnet/phttp-crypto/-/phttp-crypto-1.0.0.tgz#684815ab5c18b76f4458bf0ddf8bec4c15f653fe"
-  integrity sha512-IBeEULHWVDaQPDDU0aSZqHJ6EFPuuS2F6uj5/9wvU440JPujakDELIg8wIRVk5fjJvrjbVeVUv8c7p5dbuqhFg==
+"@hoprnet/uhttp-crypto@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@hoprnet/uhttp-crypto/-/uhttp-crypto-1.0.1.tgz#0b2f92228bb9bc14c7ada2531f5f3b7ce029e7ab"
+  integrity sha512-yvZBBuf+gUDPyABqv127v1z3+AhLtBPwmkmndKC+Rw/SJ4UGKDw3WTyk44chUQwVZlwIitWIKA+M3xZPNsxkRQ==
   dependencies:
     "@noble/ciphers" "^0.4.1"
     "@noble/curves" "^1.3.0"
     "@noble/hashes" "^1.3.3"
 
-"@hoprnet/phttp-lib@^3.0.1":
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/@hoprnet/phttp-lib/-/phttp-lib-3.0.1.tgz#2204a45c08829db85b009d5fd9d504a6c59f460f"
-  integrity sha512-+YIYJjetF/oxj06pAuHxjPlffQcMiXoJJRn2QStiriV8IarRL/bm4OnS3GOiqacLrHIt6vVrARCgTb0cagkC4Q==
+"@hoprnet/uhttp-lib@^3.0.2":
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/@hoprnet/uhttp-lib/-/uhttp-lib-3.0.2.tgz#5ad0f5fd0771cb1b1ff895d23fe3c5678c5a1b43"
+  integrity sha512-J2LDSH0Fu7DlH/e3Iv1NKW9JTb7Y7xXD1LxkuHI9hyDm3cePSG3g1f6DR1p+rJLldRFgVqnuJENOaz/kRPmx6g==
   dependencies:
-    "@hoprnet/phttp-crypto" "^1.0.0"
+    "@hoprnet/uhttp-crypto" "^1.0.1"
     debug "^4.3.4"
     isomorphic-ws "^5.0.0"
     lz-string "^1.5.0"
@@ -5142,12 +5142,7 @@ write-file-atomic@^4.0.2:
     imurmurhash "^0.1.4"
     signal-exit "^3.0.7"
 
-ws@^8.16.0:
-  version "8.16.0"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-8.16.0.tgz#d1cd774f36fbc07165066a60e40323eab6446fd4"
-  integrity sha512-HS0c//TP7Ina87TfiPUz1rQzMhHrl/SG2guqRcTOIUYD2q8uhUdNHZYJUaQ8aTGPzCh+c6oawMKW35nFl1dxyQ==
-
-ws@^8.17.0:
+ws@^8.16.0, ws@^8.17.0:
   version "8.17.0"
   resolved "https://registry.yarnpkg.com/ws/-/ws-8.17.0.tgz#d145d18eca2ed25aaf791a183903f7be5e295fea"
   integrity sha512-uJq6108EgZMAl20KagGkzCKfMEjxmKvZHG7Tlq0Z6nOky7YF7aq4mOx6xK8TJ/i1LeK4Qus7INktacctDgY8Ow==


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Renamed the application from "pHTTP Exit App" to "uHTTP exit application" across documentation and configuration files.
  - Updated project dependencies to reflect the new naming convention (`@hoprnet/phttp-lib` to `@hoprnet/uhttp-lib`).

- **Chores**
  - Updated environment variables and configuration settings to use `UHTTP` prefixes instead of `PHTTP`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->